### PR TITLE
Clear comment box on post

### DIFF
--- a/plugins/rich-editor/src/scripts/components/editor/Editor.tsx
+++ b/plugins/rich-editor/src/scripts/components/editor/Editor.tsx
@@ -130,6 +130,15 @@ export default class Editor extends React.Component<IProps, IState> {
         this.quill.on("text-change", () => {
             bodybox.value = JSON.stringify(this.quill.getContents().ops);
         });
+
+        // Listen for the legacy form event if applicable and clear the form.
+        const form = this.quill.container.closest("form");
+        if (form) {
+            form.addEventListener("X-ClearCommentForm", () => {
+                this.quill.setContents([]);
+                this.quill.setSelection(null as any, Quill.sources.USER);
+            });
+        }
     }
 
     /**

--- a/plugins/rich-editor/src/scripts/components/editor/Editor.tsx
+++ b/plugins/rich-editor/src/scripts/components/editor/Editor.tsx
@@ -32,6 +32,7 @@ export default class Editor extends React.Component<IProps, IState> {
     private hasUploadPermission: boolean;
     private quill: Quill;
     private quillMountRef: React.RefObject<HTMLDivElement> = React.createRef();
+    private allowPasteListener = true;
 
     constructor(props) {
         super(props);
@@ -135,8 +136,10 @@ export default class Editor extends React.Component<IProps, IState> {
         const form = this.quill.container.closest("form");
         if (form) {
             form.addEventListener("X-ClearCommentForm", () => {
+                this.allowPasteListener = false;
                 this.quill.setContents([]);
                 this.quill.setSelection(null as any, Quill.sources.USER);
+                this.allowPasteListener = true;
             });
         }
     }
@@ -151,14 +154,16 @@ export default class Editor extends React.Component<IProps, IState> {
         if (debug()) {
             const { bodybox } = this.props;
             bodybox.addEventListener("paste", event => {
-                event.stopPropagation();
-                event.preventDefault();
+                if (this.allowPasteListener) {
+                    event.stopPropagation();
+                    event.preventDefault();
 
-                // Get pasted data via clipboard API
-                const clipboardData = event.clipboardData || window.clipboardData;
-                const pastedData = clipboardData.getData("Text");
-                const delta = JSON.parse(pastedData);
-                this.quill.setContents(delta);
+                    // Get pasted data via clipboard API
+                    const clipboardData = event.clipboardData || window.clipboardData;
+                    const pastedData = clipboardData.getData("Text");
+                    const delta = JSON.parse(pastedData);
+                    this.quill.setContents(delta);
+                }
             });
         }
     }

--- a/plugins/rich-editor/src/scripts/entries/app.ts
+++ b/plugins/rich-editor/src/scripts/entries/app.ts
@@ -26,10 +26,15 @@ function setupEditor() {
  * Set up the editor if the someone clicks edit on a form.
  */
 function setupCommentEditForm() {
-    $(document).on("EditCommentFormLoaded", (event, container) => {
-        const $commentFormContainer = $(container).find(".richEditor");
-        if ($commentFormContainer.length > 0) {
-            mountEditor($commentFormContainer[0]);
+    document.addEventListener("X-EditCommentFormLoaded", event => {
+        const container = event.target;
+        if (!(container instanceof Element)) {
+            return;
+        }
+
+        const richEditor = container.querySelector(".richEditor");
+        if (richEditor) {
+            mountEditor(richEditor);
         }
     });
 }


### PR DESCRIPTION
Closes https://github.com/vanilla/rich-editor/issues/64
Requires https://github.com/vanilla/vanilla/pull/7418

- Clears the comment box when a comment is posted.
- Removes the rich editor's dependency on jQuery (use a native event to initialize an edit comment box instead of a jQuery one. This was the only part of the rich editor that used jquery.)