### PR TITLE
Fix embeds reloading from drafts

### DIFF
--- a/plugins/rich-editor/src/scripts/quill/blots/embeds/ExternalEmbedBlot.ts
+++ b/plugins/rich-editor/src/scripts/quill/blots/embeds/ExternalEmbedBlot.ts
@@ -19,7 +19,6 @@ const DATA_KEY = "__embed-data__";
 interface ILoaderData {
     type: "image" | "link";
     link?: string;
-    loaded?: boolean;
 }
 
 interface IEmbedUnloadedValue {
@@ -163,7 +162,6 @@ export default class ExternalEmbedBlot extends FocusableEmbedBlot {
     constructor(domNode, value: IEmbedValue, needsSetup = true) {
         super(domNode);
         if (needsSetup) {
-            value.loaderData.loaded = false;
             void this.replaceLoaderWithFinalForm(value);
         }
     }
@@ -181,10 +179,7 @@ export default class ExternalEmbedBlot extends FocusableEmbedBlot {
             .then(data => {
                 const newValue: IEmbedValue = {
                     data,
-                    loaderData: {
-                        ...value.loaderData,
-                        loaded: true,
-                    },
+                    loaderData: value.loaderData,
                 };
 
                 const loader = this.domNode.querySelector(".embedLinkLoader");
@@ -199,7 +194,10 @@ export default class ExternalEmbedBlot extends FocusableEmbedBlot {
             });
     }
 
-    private resolveDataFromValue(value: IEmbedValue) {
+    /**
+     * Normalize data and dataPromise into Promise<data>
+     */
+    private resolveDataFromValue(value: IEmbedValue): Promise<IEmbedData> {
         if ("data" in value) {
             return Promise.resolve(value.data);
         } else {

--- a/plugins/rich-editor/src/scripts/quill/blots/embeds/LoadingBlot.ts
+++ b/plugins/rich-editor/src/scripts/quill/blots/embeds/LoadingBlot.ts
@@ -49,13 +49,7 @@ export default class LoadingBlot extends FocusableEmbedBlot {
             throw new Error("A loading blot should have data set");
         }
 
-        return {
-            ...storedValue,
-            loaderData: {
-                ...storedValue.loaderData,
-                loaded: false,
-            },
-        };
+        return storedValue;
     }
 
     /**

--- a/plugins/rich-editor/src/scripts/quill/blots/embeds/LoadingBlot.ts
+++ b/plugins/rich-editor/src/scripts/quill/blots/embeds/LoadingBlot.ts
@@ -40,7 +40,7 @@ export default class LoadingBlot extends FocusableEmbedBlot {
     }
 
     /**
-     * Get the value out of a domNode. Also change "loaded" to false.
+     * Get the value out of a domNode.
      */
     public static value(element: Element): IEmbedValue {
         const storedValue = getData(element, LOADER_DATA_KEY, null);


### PR DESCRIPTION
Blocked by https://github.com/vanilla/rich-editor/pull/77. _This will need to be rebased once that merges to shrink down the diff._

Closes https://github.com/vanilla/rich-editor/issues/78

## To Test

Try to edit/reload a draft of a post with multiple embeds in it. All of the embeds should load back.

## The technical issue.

Technically this should have actually worked, but there must be something weird happening in the async/await transpilation. I switched the function to just use promises and everything seems to be working fine now.

Additionally, I was able to remove the `loaderData.isLoaded` value. It wasn't actually being used, so it was confusing to have there.