### PR TITLE
Implement additional link transforms

### DIFF
--- a/plugins/rich-editor/src/scripts/__tests__/setup.ts
+++ b/plugins/rich-editor/src/scripts/__tests__/setup.ts
@@ -7,8 +7,11 @@
 import Enzyme from "enzyme";
 import Adapter from "enzyme-adapter-react-16";
 import { importAll } from "@testroot/utility";
+import reducerRegistry from "@dashboard/state/reducerRegistry";
+import editorReducer from "@rich-editor/state/editorReducer";
 
 // Setup enzyme
 Enzyme.configure({ adapter: new Adapter() });
+reducerRegistry.register("editor", editorReducer);
 
 importAll((require as any).context("..", true, /.test.(ts|tsx)$/));

--- a/plugins/rich-editor/src/scripts/quill/ClipboardModule.test.ts
+++ b/plugins/rich-editor/src/scripts/quill/ClipboardModule.test.ts
@@ -1,0 +1,18 @@
+/**
+ * @author Adam (charrondev) Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+import ClipboardModule from "./ClipboardModule";
+import { expect } from "chai";
+
+describe("ClipboardModule.splitLinkOperationsOutOfText()", () => {
+    it("Can parse out a single link", () => {
+        const link = "https://test.com";
+        const input = `text${link} moreText`;
+        const expected = [{ insert: "text" }, { insert: link, attributes: { link } }, { insert: " moreText" }];
+
+        expect(ClipboardModule.splitLinkOperationsOutOfText(input)).deep.equals(expected);
+    });
+});

--- a/plugins/rich-editor/src/scripts/quill/ClipboardModule.test.ts
+++ b/plugins/rich-editor/src/scripts/quill/ClipboardModule.test.ts
@@ -10,9 +10,28 @@ import { expect } from "chai";
 describe("ClipboardModule.splitLinkOperationsOutOfText()", () => {
     it("Can parse out a single link", () => {
         const link = "https://test.com";
-        const input = `text${link} moreText`;
-        const expected = [{ insert: "text" }, { insert: link, attributes: { link } }, { insert: " moreText" }];
+        const input = `${link}`;
+        const expected = [{ insert: link, attributes: { link } }];
 
         expect(ClipboardModule.splitLinkOperationsOutOfText(input)).deep.equals(expected);
+    });
+
+    it("Can parse out multiple links a single link", () => {
+        const link = "https://test.com";
+        const link2 = "https://othertest.com";
+        const input = `text${link} moreText\n\n\n${link2}`;
+        const expected = [
+            { insert: "text" },
+            { insert: link, attributes: { link } },
+            { insert: " moreText\n\n\n" },
+            { insert: link2, attributes: { link: link2 } },
+        ];
+
+        expect(ClipboardModule.splitLinkOperationsOutOfText(input)).deep.equals(expected);
+    });
+
+    it("Doesn't alter operations when no links were found.", () => {
+        const input = `asdfasdfasfd\n\n\nasdfasdfhtt://asd http// ssh://asdfasfd`;
+        expect(ClipboardModule.splitLinkOperationsOutOfText(input)).equals(null);
     });
 });

--- a/plugins/rich-editor/src/scripts/quill/ClipboardModule.ts
+++ b/plugins/rich-editor/src/scripts/quill/ClipboardModule.ts
@@ -25,11 +25,17 @@ export default class ClipboardModule extends ClipboardBase {
             matches.forEach(match => {
                 const split = (inputText as string).split(match);
                 const beforeLink = split.shift();
-                ops.push({ insert: beforeLink });
+                // We don't want to insert empty ops.
+                if (beforeLink !== "") {
+                    ops.push({ insert: beforeLink });
+                }
                 ops.push({ insert: match, attributes: { link: match } });
                 inputText = split.join(match);
             });
-            ops.push({ insert: inputText });
+            // We don't want to insert empty ops.
+            if (inputText !== "") {
+                ops.push({ insert: inputText });
+            }
             return ops;
         } else {
             return null;

--- a/plugins/rich-editor/src/scripts/quill/ClipboardModule.ts
+++ b/plugins/rich-editor/src/scripts/quill/ClipboardModule.ts
@@ -90,10 +90,12 @@ export default class ClipboardModule extends ClipboardBase {
      */
     public linkMatcher = (node: Node, delta: DeltaStatic) => {
         const { textContent } = node;
-        if (node.nodeType === Node.TEXT_NODE && textContent != null && !this.inCodeFormat) {
-            const splitOps = ClipboardModule.splitLinkOperationsOutOfText(textContent);
-            if (splitOps) {
-                delta.ops = splitOps;
+        if (node.nodeType === Node.TEXT_NODE && textContent != null) {
+            if (!this.inCodeFormat) {
+                const splitOps = ClipboardModule.splitLinkOperationsOutOfText(textContent);
+                if (splitOps) {
+                    delta.ops = splitOps;
+                }
             }
         }
 
@@ -104,10 +106,13 @@ export default class ClipboardModule extends ClipboardBase {
      * Determine if we are in a code formatted item or not.
      */
     private get inCodeFormat() {
-        const selection = getStore<IState>().getState().editor.instances[getIDForQuill(this.quill)].lastGoodSelection;
+        const instance = getStore<IState>().getState().editor.instances[getIDForQuill(this.quill)];
+        if (!instance || !instance.lastGoodSelection) {
+            return false;
+        }
         return (
-            rangeContainsBlot(this.quill, CodeBlockBlot, selection) ||
-            rangeContainsBlot(this.quill, CodeBlot, selection)
+            rangeContainsBlot(this.quill, CodeBlockBlot, instance.lastGoodSelection) ||
+            rangeContainsBlot(this.quill, CodeBlot, instance.lastGoodSelection)
         );
     }
 }

--- a/plugins/rich-editor/src/scripts/quill/KeyboardBindings.ts
+++ b/plugins/rich-editor/src/scripts/quill/KeyboardBindings.ts
@@ -338,7 +338,8 @@ export default class KeyboardBindings {
         }
 
         // Bail out if the blot contents are not plian text.
-        if ((line as BlockBlot).children.length > 1 || (line as any).children.head.statics.blotName !== "text") {
+        const firstBlotName = (line as any).children.head.statics.blotName;
+        if ((line as BlockBlot).children.length > 1 || !["text", "link"].includes(firstBlotName)) {
             return true;
         }
 

--- a/plugins/rich-editor/src/scripts/quill/KeyboardBindings.ts
+++ b/plugins/rich-editor/src/scripts/quill/KeyboardBindings.ts
@@ -337,7 +337,7 @@ export default class KeyboardBindings {
             return true;
         }
 
-        // Bail out if the blot contents are not plian text.
+        // Bail out if the blot contents are not plain text or a link.
         const firstBlotName = (line as any).children.head.statics.blotName;
         if ((line as BlockBlot).children.length > 1 || !["text", "link"].includes(firstBlotName)) {
             return true;

--- a/plugins/rich-editor/src/scripts/quill/utility.ts
+++ b/plugins/rich-editor/src/scripts/quill/utility.ts
@@ -104,7 +104,7 @@ export function rangeContainsBlot(quill: Quill, blotConstructor: any, range: Ran
         const blots = quill.scroll.descendants(blotConstructor, range.index, range.length);
         return blots.length > 0;
     } else {
-        const blot = quill.scroll.descendant(blotConstructor, range.index);
+        const blot = quill.scroll.descendant(blotConstructor, range.index)[0];
         return !!blot;
     }
 }
@@ -408,5 +408,5 @@ export const SELECTION_UPDATE = "[editor] force selection update";
  * Force a selection update on all quill editors.
  */
 export function forceSelectionUpdate() {
-    document.dispatchEvent(new CustomEvent(this.SELECTION_UPDATE));
+    document.dispatchEvent(new CustomEvent(SELECTION_UPDATE));
 }

--- a/plugins/rich-editor/src/scripts/quill/utility.ts
+++ b/plugins/rich-editor/src/scripts/quill/utility.ts
@@ -402,11 +402,11 @@ export function isEmbedSelected(quill: Quill, selection?: RangeStatic | null) {
     return !!potentialEmbedBlot;
 }
 
+export const SELECTION_UPDATE = "[editor] force selection update";
+
 /**
  * Force a selection update on all quill editors.
  */
 export function forceSelectionUpdate() {
     document.dispatchEvent(new CustomEvent(this.SELECTION_UPDATE));
 }
-
-export const SELECTION_UPDATE = "[editor] force selection update";

--- a/plugins/rich-editor/src/scripts/quill/utility.ts
+++ b/plugins/rich-editor/src/scripts/quill/utility.ts
@@ -99,8 +99,14 @@ export function rangeContainsBlot(quill: Quill, blotConstructor: any, range: Ran
     if (!range) {
         return false;
     }
-    const blots = quill.scroll.descendants(blotConstructor, range.index, range.length);
-    return blots.length > 0;
+
+    if (range.length > 0) {
+        const blots = quill.scroll.descendants(blotConstructor, range.index, range.length);
+        return blots.length > 0;
+    } else {
+        const blot = quill.scroll.descendant(blotConstructor, range.index);
+        return !!blot;
+    }
 }
 
 /**


### PR DESCRIPTION
Blocked by https://github.com/vanilla/rich-editor/pull/77. _This will need to be rebased after that is merged in order to slim down the diff._
Closes https://github.com/vanilla/vanilla/issues/7411

## Testing
The specification in the issue is pretty clear I think. If you have additional questions I can answer them.

## Summary

- Transforms pasted links (even with other text around them) into text if:
  - We are __not__ pasting into an inline code or block code blot.
- Apply the link on its own line -> embed transformation to links that are already links as well.

## Notes

- I've set it up so that we don't transform a text into a link for inline code, but inline code blot gets split in half by any pasted text with the text inside of it. https://github.com/vanilla/rich-editor/issues/18#issuecomment-403615659

