### PR TITLE
Cap visible mention suggestions at 5

### DIFF
--- a/plugins/rich-editor/src/scripts/components/toolbars/pieces/MentionSuggestionList.tsx
+++ b/plugins/rich-editor/src/scripts/components/toolbars/pieces/MentionSuggestionList.tsx
@@ -94,7 +94,7 @@ class MentionSuggestionList extends React.PureComponent<IProps, IState> {
                         };
                     }
 
-                    const items = mentionProps.map(mentionProp => {
+                    const items = mentionProps.slice(0, 5).map(mentionProp => {
                         if (mentionProp.mentionData == null) {
                             return null;
                         }


### PR DESCRIPTION
Mentions were supposed to be capped at 5. When last revisiting the mention structure I forgot to reapply the limit. Mentions are already sorted at this point so I am slicing out the first 5 of the array just before rendering.