### PR TITLE
Fix paragraph menu flashing when the formatting

### DIFF
--- a/plugins/rich-editor/src/scripts/components/toolbars/ParagraphToolbar.tsx
+++ b/plugins/rich-editor/src/scripts/components/toolbars/ParagraphToolbar.tsx
@@ -232,6 +232,7 @@ export class ParagraphToolbar extends React.PureComponent<IProps, IState> {
      * Close the paragraph menu and place the selection at the end of the current selection if there is one.
      */
     private close = () => {
+        this.setState({ hasFocus: false });
         const { lastGoodSelection } = this.props.instanceState;
         const newSelection = {
             index: lastGoodSelection.index + lastGoodSelection.length,
@@ -249,7 +250,6 @@ export class ParagraphToolbar extends React.PureComponent<IProps, IState> {
         if (event.keyCode === 27 && this.state.hasFocus) {
             event.preventDefault();
             this.close();
-            this.setState({ hasFocus: false });
         }
     };
 


### PR DESCRIPTION
The paragraph menu would flash open sometimes when applying this format. This is because the close method on the paragraph menu was only setting a selection, then relying on the updated selection to propagate back to itself, which would change the focus, closing the menu. The issue was this would take a couple extra ticks causing the menu to flash as the P menu moved.

The close method now closes the menu directly, then makes it selection. The keydown listener calls close so I was able to remove the manual setting of state from it.

With the change in this PR, a valid button click will close the menu first, prevent this flashing.