### PR TITLE
Fix link toggling in firefox

### DIFF
--- a/plugins/rich-editor/src/scripts/components/toolbars/InlineToolbar.tsx
+++ b/plugins/rich-editor/src/scripts/components/toolbars/InlineToolbar.tsx
@@ -37,7 +37,12 @@ export class InlineToolbar extends React.Component<IProps, IState> {
     private formatter: Formatter;
     private linkInput: React.RefObject<HTMLInputElement> = React.createRef();
     private selfRef: React.RefObject<HTMLDivElement> = React.createRef();
-    private ignoreFocusChanges: boolean = false;
+
+    /**
+     * Temporaly remove the focus requirement on the toolbar so we can focus it.
+     * @see https://github.com/vanilla/rich-editor/pull/107
+     */
+    private ignoreLinkToolbarFocusRequirement: boolean = false;
 
     /**
      * @inheritDoc
@@ -107,7 +112,7 @@ export class InlineToolbar extends React.Component<IProps, IState> {
         const inCodeBlock = rangeContainsBlot(this.quill, CodeBlockBlot, this.props.instanceState.lastGoodSelection);
         return (
             this.state.isLinkMenuOpen &&
-            (this.hasFocus || this.ignoreFocusChanges) &&
+            (this.hasFocus || this.ignoreLinkToolbarFocusRequirement) &&
             this.isOneLineOrLess &&
             !inCodeBlock &&
             this.selectionHasContent
@@ -223,10 +228,10 @@ export class InlineToolbar extends React.Component<IProps, IState> {
             this.setState({ isLinkMenuOpen: false });
             this.formatter.link(this.props.instanceState.lastGoodSelection);
         } else {
-            this.ignoreFocusChanges = true;
+            this.ignoreLinkToolbarFocusRequirement = true;
             this.setState({ isLinkMenuOpen: true }, () => {
                 this.linkInput.current!.focus();
-                this.ignoreFocusChanges = false;
+                this.ignoreLinkToolbarFocusRequirement = false;
             });
         }
     };

--- a/plugins/rich-editor/src/scripts/components/toolbars/InlineToolbar.tsx
+++ b/plugins/rich-editor/src/scripts/components/toolbars/InlineToolbar.tsx
@@ -37,6 +37,7 @@ export class InlineToolbar extends React.Component<IProps, IState> {
     private formatter: Formatter;
     private linkInput: React.RefObject<HTMLInputElement> = React.createRef();
     private selfRef: React.RefObject<HTMLDivElement> = React.createRef();
+    private ignoreFocusChanges: boolean = false;
 
     /**
      * @inheritDoc
@@ -106,7 +107,7 @@ export class InlineToolbar extends React.Component<IProps, IState> {
         const inCodeBlock = rangeContainsBlot(this.quill, CodeBlockBlot, this.props.instanceState.lastGoodSelection);
         return (
             this.state.isLinkMenuOpen &&
-            this.hasFocus &&
+            (this.hasFocus || this.ignoreFocusChanges) &&
             this.isOneLineOrLess &&
             !inCodeBlock &&
             this.selectionHasContent
@@ -216,13 +217,16 @@ export class InlineToolbar extends React.Component<IProps, IState> {
      *
      * Opens the menu if there is no current link formatting.
      */
-    private toggleLinkMenu = () => {
+    private toggleLinkMenu = (event?: React.MouseEvent<any>) => {
+        event && event.preventDefault();
         if (typeof this.props.activeFormats.link === "string") {
             this.setState({ isLinkMenuOpen: false });
             this.formatter.link(this.props.instanceState.lastGoodSelection);
         } else {
+            this.ignoreFocusChanges = true;
             this.setState({ isLinkMenuOpen: true }, () => {
                 this.linkInput.current!.focus();
+                this.ignoreFocusChanges = false;
             });
         }
     };


### PR DESCRIPTION
https://github.com/vanilla/rich-editor/issues/105

This fix was previously in this component, and needs to come back now. I've documented its purpose a bit better inline this time around so it doesn't get removed again.

## Overview

1. Button clicked
2. Click event triggered
3. Show Link menu toggled (react state update).
4. A callback is provided to the state update to focus this input in the link.
5. Focus is moved to button.
6. Quill loses focus. We don't listen for this event, we just passively look at it.

From here on the behaviour in browsers differs.

## Chrome

7. Component updates. _Quill still reports that it has focus._
8. Our callback runs, putting focus in the input.
9. Our component picks up the new focus and updates itself. This time the link menu has focus. Now Quill reports that it does not have focus, but it doesn't matter.

## Firefox

7. Component updates. _Quill still reports that it does not have focus._
8. The component re-renders with no toolbars.
8. Our callback runs, but cannot put focus in the input because it is not mounted. The button toolbar disappears and focus is moved to the document.
9. No toolbars render because neither quill or a toolbar has focus.

## The fix

The fix is tell the component to ignore quill while we are queueing our focusing of the link input. We did this previously but it was removed in recent revision.