### PR TITLE
Update rich editor translation strings

### DIFF
--- a/plugins/rich-editor/RichEditorPlugin.php
+++ b/plugins/rich-editor/RichEditorPlugin.php
@@ -163,7 +163,7 @@ class RichEditorPlugin extends Gdn_Plugin {
         Gdn_ConfigurationModel $configModel
     ): string {
         $enableRichQuotes = t('Enable Rich Quotes');
-        $richEditorQuotesNotes =  t('RichEditor.QuoteEnable.Notes1', 'Use the following option to enable quotes for the Rich Editor. This will only apply if the default formatter is "Rich".');
+        $richEditorQuotesNotes =  t('RichEditor.QuoteEnable.Notes', 'Use the following option to enable quotes for the Rich Editor. This will only apply if the default formatter is "Rich".');
         $label = '<p class="info">'.$richEditorQuotesNotes.'</p>';
         $configModel->setField(self::QUOTE_CONFIG_ENABLE);
 

--- a/plugins/rich-editor/locale/en.php
+++ b/plugins/rich-editor/locale/en.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * @copyright 2009-2018 Vanilla Forums Inc.
+ * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
+ */
+
+// Dashboard
+$Definition['Enable Rich Quotes'] = 'Enable Rich Quotes';
+$Definition['RichEditor.QuoteEnable.Notes'] = 'Use the following option to enable quotes for the Rich Editor. This will only apply if the default formatter is "Rich".';
+
 // Long Descriptions
 $Definition['richEditor.description.title'] = 'Rich Text Editor.';
 $Definition['richEditor.description.paragraphMenu'] = 'To edit a paragraph\'s style, hit tab to get to the paragraph menu. From there you will be able to pick one style. Nothing defaults to paragraph.';

--- a/plugins/rich-editor/locale/en.php
+++ b/plugins/rich-editor/locale/en.php
@@ -74,3 +74,6 @@ $Definition['Embed'] = 'Embed';
 $Definition['▼'] = '▼';
 $Definition['Error'] = 'Error';
 $Definition['▲'] = '▲';
+
+// Quotes
+$Definition['Toggle Quote'] = 'Toggle Quote';

--- a/plugins/rich-editor/locale/en.php
+++ b/plugins/rich-editor/locale/en.php
@@ -1,11 +1,12 @@
 <?php
+// Long Descriptions
 $Definition['richEditor.description.title'] = 'Rich Text Editor.';
 $Definition['richEditor.description.paragraphMenu'] = 'To edit a paragraph\'s style, hit tab to get to the paragraph menu. From there you will be able to pick one style. Nothing defaults to paragraph.';
 $Definition['richEditor.description.inlineMenu'] = 'An inline formatting menu will show up when you select text. Hit tab to get into that menu.';
 $Definition['richEditor.description.embed'] = 'Some elements, such as rich link embeds, images, loading indicators, and error messages may get inserted into the editor. You may navigate to these using the arrow keys inside of the editor and delete them with the delete or backspace key.';
 $Definition['richEditor.externalEmbed.description'] = 'This is an embed external element. It can be deleted using the delete key or the backspace key. To view the full element, press the preview button below.';
 
-// Formatting Meus
+// Formatting Menus
 $Definition['Inline Level Formatting Menu'] = 'Inline Level Formatting Menu';
 $Definition['Format as Bold'] = 'Format as Bold';
 $Definition['Bold'] = 'Bold';

--- a/plugins/rich-editor/locale/en.php
+++ b/plugins/rich-editor/locale/en.php
@@ -4,45 +4,63 @@ $Definition['richEditor.description.paragraphMenu'] = 'To edit a paragraph\'s st
 $Definition['richEditor.description.inlineMenu'] = 'An inline formatting menu will show up when you select text. Hit tab to get into that menu.';
 $Definition['richEditor.description.embed'] = 'Some elements, such as rich link embeds, images, loading indicators, and error messages may get inserted into the editor. You may navigate to these using the arrow keys inside of the editor and delete them with the delete or backspace key.';
 $Definition['richEditor.externalEmbed.description'] = 'This is an embed external element. It can be deleted using the delete key or the backspace key. To view the full element, press the preview button below.';
-$Definition['richEditor.menu.blockquote'] = 'Blockquote';
-$Definition['richEditor.menu.pilcrow'] = 'No Block Formatting';
-$Definition['richEditor.menu.bold'] = 'Bold';
-$Definition['richEditor.menu.code'] = 'Inline Code Block';
-$Definition['richEditor.menu.codeBlock'] = 'Code Block';
-$Definition['richEditor.menu.title'] = 'Title';
-$Definition['richEditor.menu.subtitle'] = 'Subtitle';
-$Definition['richEditor.menu.inline'] = 'Inline Style Menu';
-$Definition['richEditor.menu.italic'] = 'Italic';
-$Definition['richEditor.menu.link'] = 'Link';
-$Definition['richEditor.menu.paragraph'] = 'Paragraph Style Menu';
-$Definition['richEditor.menu.spoiler'] = 'Spoiler';
-$Definition['richEditor.menu.subheading'] = 'Subheading';
-$Definition['richEditor.menu.strike'] = 'Strike Through';
 
-$Definition['Emoji Categories'] = 'Emoji Categories';
-$Definition['Get Help on Inserting Media'] = 'Get Help on Inserting Media';
-$Definition['In emoji category: '] = 'In emoji category: ';
-$Definition['Inline Menu Available'] = 'Inline Menu Available';
-$Definition['Insert an embedded web page, or video into your message'] = 'Insert an embedded web page, or video into your message';
-$Definition['Insert an emoji in your message.'] = 'Insert an emoji in your message.';
-$Definition['Jump past emoji list, to emoji categories.'] = 'Jump past emoji list, to emoji categories.';
-$Definition['Jumped to emoji category: '] = 'Jumped to emoji category: ';
-$Definition['Paste the URL of the media you want.'] = 'Paste the URL of the media you want.';
+// Formatting Meus
+$Definition['Inline Level Formatting Menu'] = 'Inline Level Formatting Menu';
+$Definition['Format as Bold'] = 'Format as Bold';
+$Definition['Bold'] = 'Bold';
+$Definition['Format as Italic'] = 'Format as Italic';
+$Definition['Italic'] = 'Italic';
+$Definition['Format as Strikethrough'] = 'Format as Strikethrough';
+$Definition['Strikethrough'] = 'Strikethrough';
+$Definition['Format as Inline Code'] = 'Format as Inline Code';
+$Definition['Paragraph Code Block'] = 'Paragraph Code Block';
+$Definition['Format as Link'] = 'Format as Link';
+$Definition['Link'] = 'Link';
+$Definition['Insert Url'] = 'Insert Url';
 $Definition['Paste or type a link…'] = 'Paste or type a link…';
-$Definition['Smileys & Faces'] = 'Smileys & Faces';
-$Definition['richEditor.emojiPicker.description.pageUpDown'] = 'Use keyboard shortcuts "page up" and "page down" to cycle through available categories when menu is open.';
+$Definition['×'] = '×';
+$Definition['Close'] = 'Close';
+$Definition['Line Level Formatting Menu'] = 'Line Level Formatting Menu';
+$Definition['Paragraph'] = 'Paragraph';
+$Definition['Format as Paragraph'] = 'Format as Paragraph';
+$Definition['Subtitle'] = 'Subtitle';
+$Definition['Format as Title'] = 'Format as Title';
+$Definition['Sub Subtitle'] = 'Sub Subtitle';
+$Definition['Format as Subtitle'] = 'Format as Subtitle';
+$Definition['Quote'] = 'Quote';
+$Definition['Format as blockquote'] = 'Format as blockquote';
+$Definition['Format as code block'] = 'Format as code block';
+$Definition['Spoiler'] = 'Spoiler';
+$Definition['Format as spoiler'] = 'Format as spoiler';
+$Definition['Inline Menu Available'] = 'Inline Menu Available';
 
-// Emoji Group Names
-$Definition['smileys-people'] = 'Smileys and People';
-$Definition['animals-nature'] = 'Animals and Nature';
-$Definition['food-drink'] = 'Food and Drink';
-$Definition['travel-places'] = 'Travel and Places';
-$Definition['activities'] = 'Activities';
-$Definition['objects'] = 'Objects';
-$Definition['symbols'] = 'Symbols';
-$Definition['flags'] = 'Flags';
+// Emoji Picker
+$Definition['Emoji'] = 'Emoji';
+$Definition['Emojis'] = 'Emojis';
+$Definition['Insert an emoji in your message.'] = 'Insert an emoji in your message.';
+$Definition['Use keyboard shortcuts "page up" and "page down" to cycle through available categories when menu is open.'] = 'Use keyboard shortcuts "page up" and "page down" to cycle through available categories when menu is open.';
+$Definition['Jump past emoji list, to emoji categories.'] = 'Jump past emoji list, to emoji categories.';
+$Definition['Emoji Categories'] = 'Emoji Categories';
+$Definition['Jump to emoji category: '] = 'Jump to emoji category: ';
+$Definition['In emoji category: '] = 'In emoji category: ';
 
-// Mentions
-$Definition['@mention user suggestions'] = '@mention user suggestions';
-$Definition['@mention a user'] = '@mention a user';
-$Definition['No results found'] = 'No results found';
+// Emoji Categories
+$Definition['Smileys & People'] = 'Smileys & People';
+$Definition['Animals & Nature'] = 'Animals & Nature';
+$Definition['Food & Drink'] = 'Food & Drink';
+$Definition['Travel & Places'] = 'Travel & Places';
+$Definition['Activities'] = 'Activities';
+$Definition['Objects'] = 'Objects';
+$Definition['Symbols'] = 'Symbols';
+$Definition['Flags'] = 'Flags';
+
+// Media Insertion
+$Definition['Image'] = 'Image';
+$Definition['Insert Media'] = 'Insert Media';
+$Definition['Paste the URL of the media you want.'] = 'Paste the URL of the media you want.';
+$Definition['http://'] = 'http://';
+$Definition['Embed'] = 'Embed';
+$Definition['▼'] = '▼';
+$Definition['Error'] = 'Error';
+$Definition['▲'] = '▲';

--- a/plugins/rich-editor/src/scripts/components/icons.tsx
+++ b/plugins/rich-editor/src/scripts/components/icons.tsx
@@ -111,7 +111,7 @@ export function close() {
 export function pilcrow() {
     return (
         <svg className="richEditorButton-icon" viewBox="0 0 24 24">
-            <title>{t("richEditor.menu.pilcrow")}</title>
+            <title>{t("Paragraph")}</title>
             <path
                 fill="currentColor"
                 fillRule="evenodd"
@@ -186,7 +186,7 @@ export function spoiler() {
     );
 }
 
-export function emojiGroup_smileysPeople(group = "smileys-people") {
+export function emojiGroup_smileysPeople(group = "Smileys & People") {
     return (
         <svg className="emojiGroup-icon" viewBox="0 0 24 24">
             <title>{t(group)}</title>
@@ -198,7 +198,7 @@ export function emojiGroup_smileysPeople(group = "smileys-people") {
     );
 }
 
-export function emojiGroup_animalsNature(group = "animals-nature") {
+export function emojiGroup_animalsNature(group = "Animals & Nature") {
     return (
         <svg className="emojiGroup-icon" viewBox="0 0 24 24">
             <title>{t(group)}</title>
@@ -210,7 +210,7 @@ export function emojiGroup_animalsNature(group = "animals-nature") {
     );
 }
 
-export function emojiGroup_foodDrink(group = "food-drink") {
+export function emojiGroup_foodDrink(group = "Food & Drink") {
     return (
         <svg className="emojiGroup-icon" viewBox="0 0 24 24">
             <title>{t(group)}</title>
@@ -222,7 +222,7 @@ export function emojiGroup_foodDrink(group = "food-drink") {
     );
 }
 
-export function emojiGroup_travelPlaces(group = "travel-places") {
+export function emojiGroup_travelPlaces(group = "Travel & Places") {
     return (
         <svg className="emojiGroup-icon" viewBox="0 0 24 24">
             <title>{t(group)}</title>
@@ -234,7 +234,7 @@ export function emojiGroup_travelPlaces(group = "travel-places") {
     );
 }
 
-export function emojiGroup_activities(group = "activities") {
+export function emojiGroup_activities(group = "Activities") {
     return (
         <svg className="emojiGroup-icon" viewBox="0 0 24 24">
             <title>{t(group)}</title>
@@ -246,7 +246,7 @@ export function emojiGroup_activities(group = "activities") {
     );
 }
 
-export function emojiGroup_objects(group = "objects") {
+export function emojiGroup_objects(group = "Objects") {
     return (
         <svg className="emojiGroup-icon" viewBox="0 0 24 24">
             <title>{t(group)}</title>
@@ -259,7 +259,7 @@ export function emojiGroup_objects(group = "objects") {
     );
 }
 
-export function emojiGroup_symbols(group = "symbols") {
+export function emojiGroup_symbols(group = "Symbols") {
     return (
         <svg className="emojiGroup-icon" viewBox="0 0 24 24">
             <title>{t(group)}</title>
@@ -271,7 +271,7 @@ export function emojiGroup_symbols(group = "symbols") {
     );
 }
 
-export function emojiGroup_flags(group = "flags") {
+export function emojiGroup_flags(group = "Flags") {
     return (
         <svg className="emojiGroup-icon" viewBox="0 0 24 24">
             <title>{t(group)}</title>

--- a/plugins/rich-editor/src/scripts/components/popovers/pieces/EmojiPicker.tsx
+++ b/plugins/rich-editor/src/scripts/components/popovers/pieces/EmojiPicker.tsx
@@ -32,7 +32,6 @@ EMOJIS.forEach((data, key) => {
     }
 });
 
-const emojiGroupLength = Object.values(EMOJI_GROUPS).length;
 const lastEmojiIndex = EMOJIS.length - 1;
 
 interface IProps extends IWithEditorProps, IPopoverControllerChildParameters {
@@ -95,24 +94,25 @@ export class EmojiPicker extends React.PureComponent<IProps, IState> {
 
         const footer = (
             <div id={this.categoryPickerID} className="emojiGroups" aria-label={t("Emoji Categories")} tabIndex={-1}>
-                {Object.values(EMOJI_GROUPS).map((groupName: string, groupKey) => {
-                    const isSelected = this.state.selectedGroupIndex === groupKey;
+                {Object.values(EMOJI_GROUPS).map((group, groupIndex) => {
+                    const { name, icon } = group;
+                    const isSelected = this.state.selectedGroupIndex === groupIndex;
                     const buttonClasses = classNames("richEditor-button", "emojiGroup", { isSelected });
 
-                    const onClick = event => this.handleCategoryClick(event, groupKey);
+                    const onClick = event => this.handleCategoryClick(event, groupIndex);
 
                     return (
                         <button
                             type="button"
                             onClick={onClick}
                             aria-current={isSelected}
-                            aria-label={t("Jump to emoji category: ") + t(groupName)}
-                            key={"emojiGroup-" + groupName}
-                            title={t(groupName)}
+                            aria-label={t("Jump to emoji category: ") + t(name)}
+                            key={"emojiGroup-" + name}
+                            title={t(name)}
                             className={buttonClasses}
                         >
-                            {this.getGroupSVGPath(groupName)}
-                            <span className="sr-only">{t("Jump to Category: ") + t(groupName)}</span>
+                            {icon}
+                            <span className="sr-only">{t("Jump to emoji category: ") + t(name)}</span>
                         </button>
                     );
                 })}
@@ -195,8 +195,8 @@ export class EmojiPicker extends React.PureComponent<IProps, IState> {
         this.setState({
             rowStartIndex: event.rowStartIndex,
             selectedGroupIndex,
-            alertMessage: t("In emoji category: ") + t(EMOJI_GROUPS[selectedGroupIndex]),
-            title: t(EMOJI_GROUPS[selectedGroupIndex]),
+            alertMessage: t("In emoji category: ") + t(EMOJI_GROUPS[selectedGroupIndex].name),
+            title: t(EMOJI_GROUPS[selectedGroupIndex].name),
         });
     };
 
@@ -214,7 +214,7 @@ export class EmojiPicker extends React.PureComponent<IProps, IState> {
         this.setState({
             activeIndex: newIndex,
             scrollToRow: this.getRowFromIndex(newIndex),
-            alertMessage: t("Jumped to emoji category: ") + t(EMOJI_GROUPS[categoryID]),
+            alertMessage: t("Jumped to emoji category: ") + t(EMOJI_GROUPS[categoryID].name),
         });
     };
 
@@ -239,14 +239,6 @@ export class EmojiPicker extends React.PureComponent<IProps, IState> {
                 onKeyRight={this.jumpIndexRight}
             />
         ) : null;
-    };
-
-    /**
-     * Get Group SVG Path
-     */
-    private getGroupSVGPath = (groupName: string) => {
-        const functionSuffix = groupName.replace(/-([a-z])/g, g => g[1].toUpperCase());
-        return Icons["emojiGroup_" + functionSuffix]();
     };
 
     /**

--- a/plugins/rich-editor/src/scripts/components/popovers/pieces/emojiData.ts
+++ b/plugins/rich-editor/src/scripts/components/popovers/pieces/emojiData.ts
@@ -13,15 +13,38 @@
  * @license https://opensource.org/licenses/GPL-2.0 GPL-2.0
  */
 
+import { t } from "@dashboard/application";
+import {emojiGroup_animalsNature, emojiGroup_foodDrink, emojiGroup_travelPlaces, emojiGroup_activities, emojiGroup_objects, emojiGroup_symbols, emojiGroup_flags} from "@rich-editor/components/icons";
+
 export const EMOJI_GROUPS = [
-    "smileys-people",
-    "animals-nature",
-    "food-drink",
-    "travel-places",
-    "activities",
-    "objects",
-    "symbols",
-    "flags",
+    {
+        name: "Smileys & People",
+        icon: emojiGroup_animalsNature(),
+    },
+    {
+        name: "Food & Drink",
+        icon: emojiGroup_foodDrink(),
+    },
+    {
+        name: "Travel & Places",
+        icon: emojiGroup_animalsNature(),
+    },
+    {
+        name: "Activities",
+        icon: emojiGroup_activities(),
+    },
+    {
+        name: "Objects",
+        icon: emojiGroup_objects(),
+    },
+    {
+        name: "Symbols",
+        icon: emojiGroup_symbols(),
+    },
+    {
+        name: "Flags",
+        icon: emojiGroup_flags(),
+    },
 ];
 
 export const EMOJIS = [

--- a/plugins/rich-editor/src/scripts/components/toolbars/ParagraphToolbar.tsx
+++ b/plugins/rich-editor/src/scripts/components/toolbars/ParagraphToolbar.tsx
@@ -86,7 +86,7 @@ export class ParagraphToolbar extends React.PureComponent<IProps, IState> {
                     type="button"
                     id={this.buttonID}
                     ref={this.buttonRef}
-                    aria-label={t("richEditor.menu.paragraph")}
+                    aria-label={t("Line Level Formatting Menu")}
                     aria-controls={this.menuID}
                     aria-expanded={this.isMenuVisible}
                     disabled={!this.isPilcrowVisible}


### PR DESCRIPTION
Blocking https://github.com/vanilla/locales/pull/71

Updates all of the translation strings for the rich editor. Many missing ones were added and the translation keys have been replaced with the source string if it is short. This is how @tburry requested the keys be done.

I've caught a couple of missing ones by temporarily logging any keys that didn't have a translation match on the client.

To make specifying translation strings for the emoji picker clearer I've updated the emoji groups to have both the icon and name specified instead of determining the icon name from the group.