### PR TITLE
Fix broken embed insert

### DIFF
--- a/plugins/rich-editor/src/scripts/components/editor/Editor.tsx
+++ b/plugins/rich-editor/src/scripts/components/editor/Editor.tsx
@@ -127,9 +127,7 @@ export default class Editor extends React.Component<IProps> {
 
     private onQuillUpdate = (type, newValue, oldValue, source) => {
         if (source !== Quill.sources.SILENT) {
-            window.requestAnimationFrame(() => {
-                this.store.dispatch(actions.setSelection(this.editorID, this.quill.getSelection()));
-            });
+            this.store.dispatch(actions.setSelection(this.editorID, this.quill.getSelection()));
         }
     };
 


### PR DESCRIPTION
While making the selection updating asynchronous, we broke our embed insertion keyboard shortcut.

This PR reverts that change.

After this the enter to insert an Embed keyboard shortcut should be working again.